### PR TITLE
Improve default client/index.html

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,17 +1,17 @@
 <!doctype>
 <html lang="fr">
-    <head>
-        <meta charset="utf-8">
-        <!-- Load Vue followed by Vue Router -->
-        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-        <script src="https://unpkg.com/http-vue-loader"></script>
-        <script src="http://npmcdn.com/vue-router/dist/vue-router.js"></script>
-    </head>
-    <body>
-        <div id="app">
-          <hello-world></hello-world>
-          <hello-other-world></hello-other-world>
-        </div>
-        <script src="/vue-application.js"></script>
-    </body>
+  <head>
+    <meta charset="utf-8">
+    <!-- Load Vue followed by Vue Router -->
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="https://unpkg.com/http-vue-loader"></script>
+    <script src="http://npmcdn.com/vue-router/dist/vue-router.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <hello-world></hello-world>
+      <hello-other-world></hello-other-world>
+    </div>
+    <script src="/vue-application.js"></script>
+  </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <!-- Load Vue followed by Vue Router -->
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/http-vue-loader/src/httpVueLoader.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue-router/dist/vue-router.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/http-vue-loader/src/httpVueLoader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue-router/dist/vue-router.js"></script>
   </head>
   <body>
     <div id="app">

--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <!-- Load Vue followed by Vue Router -->
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-    <script src="https://unpkg.com/http-vue-loader"></script>
-    <script src="http://npmcdn.com/vue-router/dist/vue-router.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/http-vue-loader/src/httpVueLoader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue-router/dist/vue-router.min.js"></script>
   </head>
   <body>
     <div id="app">

--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!doctype>
+<!DOCTYPE html>
 <html lang="fr">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
This pull request includes four main improvements:
1. Fix indentation by using two spaces in all files (already the case everywhere except in client/index.html, which had a mix of two and four spaces)
2. Use the conventional doctype tag (recommended by [W3Schools](https://www.w3schools.com/tags/tag_doctype.asp) and [MDN web docs](https://developer.mozilla.org/en-US/docs/Glossary/Doctype))
3. Use the same CDN for all three dependencies, which speeds up page load since one DNS request is sufficient to resolve the CDN's IP address, rather than three separate ones
4. Use the secure version of the CDNs for loading dependencies, preventing a MITM attack which would allow an arbitrary user to control any student's browser page during development